### PR TITLE
refactor: align migration API with sea-orm-migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 sea-orm-spanner/target/rust-analyzer/flycheck0
 sea-orm/
 sea-orm-spanner-plan.md
+**/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.75"
-repository = "https://github.com/user/sea-orm-spanner"
+repository = "https://github.com/jubilee-works/sea-spanner"
 keywords = ["spanner", "sea-orm", "orm", "database", "google-cloud"]
 categories = ["database"]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sea-ORM Spanner
+# sea-spanner
 
 Google Cloud Spanner backend for [SeaORM](https://www.sea-ql.org/SeaORM/).
 
@@ -120,32 +120,47 @@ cargo run -p migration -- generate create_users_table
 ### Write Migration
 
 ```rust
-use sea_orm::DbErr;
-use sea_orm_migration_spanner::{SpannerMigrationTrait, SpannerSchemaManager};
+use sea_orm_migration_spanner::prelude::*;
 
 pub struct Migration;
 
-#[async_trait::async_trait]
-impl SpannerMigrationTrait for Migration {
+impl MigrationName for Migration {
     fn name(&self) -> &str {
         "m20220101_000001_create_users"
     }
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
-        manager.create_table(
-            "CREATE TABLE users (
-                id STRING(36) NOT NULL,
-                name STRING(255) NOT NULL,
-                email STRING(255) NOT NULL,
-                created_at TIMESTAMP NOT NULL,
-            ) PRIMARY KEY (id)"
-        ).await
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                SpannerTableBuilder::new()
+                    .table("users")
+                    .string("id", Some(36), true)
+                    .string("name", Some(255), true)
+                    .string("email", Some(255), true)
+                    .timestamp("created_at", true)
+                    .primary_key(["id"]),
+            )
+            .await
     }
 
-    async fn down(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager.drop_table("users").await
     }
 }
+```
+
+You can also use raw DDL if needed:
+
+```rust
+manager.create_table_raw(
+    "CREATE TABLE users (
+        id STRING(36) NOT NULL,
+        name STRING(255) NOT NULL,
+    ) PRIMARY KEY (id)"
+).await
 ```
 
 ### Run Migrations

--- a/examples/basic-crud/src/main.rs
+++ b/examples/basic-crud/src/main.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, PaginatorTrait, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, PaginatorTrait, QueryFilter, Set,
+};
 use sea_orm_spanner::SpannerDatabase;
 
 mod entities;
@@ -48,7 +50,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("\n--- INSERT more users ---");
-    for (name, email) in [("Bob", "bob@example.com"), ("Charlie", "charlie@example.com")] {
+    for (name, email) in [
+        ("Bob", "bob@example.com"),
+        ("Charlie", "charlie@example.com"),
+    ] {
         let u = user::ActiveModel {
             id: Set(uuid::Uuid::new_v4().to_string()),
             name: Set(name.to_string()),
@@ -147,15 +152,13 @@ async fn setup_emulator_database() -> Result<(), Box<dyn std::error::Error>> {
             CreateDatabaseRequest {
                 parent: instance_path.clone(),
                 create_statement: format!("CREATE DATABASE `{}`", DATABASE),
-                extra_statements: vec![
-                    "CREATE TABLE users (
+                extra_statements: vec!["CREATE TABLE users (
                     id STRING(36) NOT NULL,
                     name STRING(255) NOT NULL,
                     email STRING(255) NOT NULL,
                     created_at TIMESTAMP NOT NULL,
                 ) PRIMARY KEY (id)"
-                        .to_string(),
-                ],
+                    .to_string()],
                 encryption_config: None,
                 database_dialect: DatabaseDialect::GoogleStandardSql.into(),
             },

--- a/examples/migration/src/lib.rs
+++ b/examples/migration/src/lib.rs
@@ -1,12 +1,12 @@
 mod m20220101_000001_create_users;
 mod m20220102_000001_create_posts;
 
-use sea_orm_migration_spanner::{SpannerMigrationTrait, SpannerMigratorTrait};
+use sea_orm_migration_spanner::prelude::*;
 
 pub struct Migrator;
 
-impl SpannerMigratorTrait for Migrator {
-    fn migrations() -> Vec<Box<dyn SpannerMigrationTrait>> {
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
             Box::new(m20220101_000001_create_users::Migration),
             Box::new(m20220102_000001_create_posts::Migration),

--- a/examples/migration/src/m20220101_000001_create_users.rs
+++ b/examples/migration/src/m20220101_000001_create_users.rs
@@ -1,28 +1,30 @@
-use sea_orm::DbErr;
-use sea_orm_migration_spanner::{SpannerMigrationTrait, SpannerSchemaManager};
+use sea_orm_migration_spanner::prelude::*;
 
 pub struct Migration;
 
-#[async_trait::async_trait]
-impl SpannerMigrationTrait for Migration {
+impl MigrationName for Migration {
     fn name(&self) -> &str {
         "m20220101_000001_create_users"
     }
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .create_table(
-                "CREATE TABLE users (
-                    id STRING(36) NOT NULL,
-                    name STRING(255) NOT NULL,
-                    email STRING(255) NOT NULL,
-                    created_at TIMESTAMP NOT NULL,
-                ) PRIMARY KEY (id)",
+                SpannerTableBuilder::new()
+                    .table("users")
+                    .string("id", Some(36), true)
+                    .string("name", Some(255), true)
+                    .string("email", Some(255), true)
+                    .timestamp("created_at", true)
+                    .primary_key(["id"]),
             )
             .await
     }
 
-    async fn down(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager.drop_table("users").await
     }
 }

--- a/examples/migration/src/m20220102_000001_create_posts.rs
+++ b/examples/migration/src/m20220102_000001_create_posts.rs
@@ -1,30 +1,32 @@
-use sea_orm::DbErr;
-use sea_orm_migration_spanner::{SpannerMigrationTrait, SpannerSchemaManager};
+use sea_orm_migration_spanner::prelude::*;
 
 pub struct Migration;
 
-#[async_trait::async_trait]
-impl SpannerMigrationTrait for Migration {
+impl MigrationName for Migration {
     fn name(&self) -> &str {
         "m20220102_000001_create_posts"
     }
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .create_table(
-                "CREATE TABLE posts (
-                    id STRING(36) NOT NULL,
-                    user_id STRING(36) NOT NULL,
-                    title STRING(255) NOT NULL,
-                    content STRING(MAX),
-                    published BOOL NOT NULL,
-                    created_at TIMESTAMP NOT NULL,
-                ) PRIMARY KEY (id)",
+                SpannerTableBuilder::new()
+                    .table("posts")
+                    .string("id", Some(36), true)
+                    .string("user_id", Some(36), true)
+                    .string("title", Some(255), true)
+                    .string("content", None, false)
+                    .bool("published", true)
+                    .timestamp("created_at", true)
+                    .primary_key(["id"]),
             )
             .await
     }
 
-    async fn down(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager.drop_table("posts").await
     }
 }

--- a/examples/migration/src/main.rs
+++ b/examples/migration/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use migration::Migrator;
-use sea_orm_migration_spanner::SpannerMigratorTrait;
+use sea_orm_migration_spanner::MigratorTrait;
 
 #[derive(Parser)]
 #[command(name = "migration")]
@@ -22,7 +22,12 @@ struct Cli {
 enum Commands {
     #[command(about = "Initialize migration directory")]
     Init {
-        #[arg(short, long, default_value = "./migration", help = "Migration directory path")]
+        #[arg(
+            short,
+            long,
+            default_value = "./migration",
+            help = "Migration directory path"
+        )]
         dir: String,
     },
 
@@ -40,7 +45,12 @@ enum Commands {
 
     #[command(about = "Rollback applied migrations")]
     Down {
-        #[arg(short, long, default_value = "1", help = "Number of migrations to rollback")]
+        #[arg(
+            short,
+            long,
+            default_value = "1",
+            help = "Number of migrations to rollback"
+        )]
         num: u32,
     },
 

--- a/sea-orm-migration-spanner/Cargo.toml
+++ b/sea-orm-migration-spanner/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 sea-orm = { version = "1.1", features = ["runtime-tokio-native-tls", "macros"] }
 sea-orm-spanner = { path = "../sea-orm-spanner" }
+sea-query-spanner = { path = "../sea-query-spanner" }
 google-cloud-spanner = "0.12"
 google-cloud-googleapis = { version = "0.6.0", features = ["spanner"] }
 async-trait = "0.1"

--- a/sea-orm-migration-spanner/src/bin/migrate.rs
+++ b/sea-orm-migration-spanner/src/bin/migrate.rs
@@ -32,7 +32,12 @@ enum Commands {
 
     #[command(about = "Rollback applied migrations")]
     Down {
-        #[arg(short, long, default_value = "1", help = "Number of migrations to rollback")]
+        #[arg(
+            short,
+            long,
+            default_value = "1",
+            help = "Number of migrations to rollback"
+        )]
         num: u32,
     },
 

--- a/sea-orm-migration-spanner/src/cli.rs
+++ b/sea-orm-migration-spanner/src/cli.rs
@@ -258,7 +258,11 @@ impl SpannerMigrationTrait for Migration {{
     Ok(())
 }
 
-fn write_file(base_dir: &str, filename: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn write_file(
+    base_dir: &str,
+    filename: &str,
+    content: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let filepath = format!("{}{}", base_dir, filename);
     println!("Creating file: {}", filepath);
 

--- a/sea-orm-migration-spanner/src/lib.rs
+++ b/sea-orm-migration-spanner/src/lib.rs
@@ -1,8 +1,10 @@
 mod cli;
 mod migrator;
+pub mod prelude;
 mod schema;
 
 pub use cli::{run_migrate_generate, run_migrate_init};
-pub use migrator::{Migration, MigrationStatus, SpannerMigrationTrait, SpannerMigratorTrait};
-pub use schema::SpannerSchemaManager;
+pub use migrator::{Migration, MigrationName, MigrationStatus, MigrationTrait, MigratorTrait};
+pub use schema::SchemaManager;
 pub use sea_orm_spanner::SpannerDatabase;
+pub use sea_query_spanner::{SpannerAlterTable, SpannerIndexBuilder, SpannerTableBuilder};

--- a/sea-orm-migration-spanner/src/migrator.rs
+++ b/sea-orm-migration-spanner/src/migrator.rs
@@ -1,6 +1,6 @@
-use crate::schema::SpannerSchemaManager;
-use sea_orm::{ActiveValue, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
+use crate::schema::SchemaManager;
 use sea_orm::sea_query::{Alias, Expr, Order, Query};
+use sea_orm::{ActiveValue, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
 use sea_orm_spanner::SpannerDatabase;
 use std::collections::HashSet;
 use std::time::SystemTime;
@@ -35,7 +35,7 @@ pub enum MigrationStatus {
 }
 
 pub struct Migration {
-    migration: Box<dyn SpannerMigrationTrait>,
+    migration: Box<dyn MigrationTrait>,
     status: MigrationStatus,
 }
 
@@ -49,13 +49,15 @@ impl Migration {
     }
 }
 
-#[async_trait::async_trait]
-pub trait SpannerMigrationTrait: Send + Sync {
+pub trait MigrationName {
     fn name(&self) -> &str;
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr>;
+#[async_trait::async_trait]
+pub trait MigrationTrait: MigrationName + Send + Sync {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr>;
 
-    async fn down(&self, _manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         Err(DbErr::Migration(
             "Rollback not implemented for this migration".to_owned(),
         ))
@@ -63,8 +65,8 @@ pub trait SpannerMigrationTrait: Send + Sync {
 }
 
 #[async_trait::async_trait]
-pub trait SpannerMigratorTrait: Send {
-    fn migrations() -> Vec<Box<dyn SpannerMigrationTrait>>;
+pub trait MigratorTrait: Send {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>>;
 
     fn get_migration_files() -> Vec<Migration> {
         Self::migrations()
@@ -77,8 +79,8 @@ pub trait SpannerMigratorTrait: Send {
     }
 
     async fn install(database_path: &str) -> Result<(), DbErr> {
-        let schema_manager = SpannerSchemaManager::new(database_path);
-        schema_manager.create_table(MIGRATIONS_TABLE_DDL).await
+        let schema_manager = SchemaManager::new(database_path);
+        schema_manager.create_table_raw(MIGRATIONS_TABLE_DDL).await
     }
 
     async fn get_applied_versions(database_path: &str) -> Result<HashSet<String>, DbErr> {
@@ -149,7 +151,7 @@ pub trait SpannerMigratorTrait: Send {
             return Ok(());
         }
 
-        let schema_manager = SpannerSchemaManager::new(database_path);
+        let schema_manager = SchemaManager::new(database_path);
         let db = SpannerDatabase::connect(database_path).await?;
 
         let to_apply: Vec<_> = match steps {
@@ -202,7 +204,7 @@ pub trait SpannerMigratorTrait: Send {
             return Ok(());
         }
 
-        let schema_manager = SpannerSchemaManager::new(database_path);
+        let schema_manager = SchemaManager::new(database_path);
         let db = SpannerDatabase::connect(database_path).await?;
 
         let to_rollback: Vec<_> = match steps {
@@ -235,7 +237,7 @@ pub trait SpannerMigratorTrait: Send {
         info!("Dropping all tables and reapplying migrations");
         println!("Dropping all tables and reapplying migrations");
 
-        let schema_manager = SpannerSchemaManager::new(database_path);
+        let schema_manager = SchemaManager::new(database_path);
 
         let migrations = Self::get_migration_files();
         for migration in migrations.iter().rev() {
@@ -250,7 +252,7 @@ pub trait SpannerMigratorTrait: Send {
     async fn reset(database_path: &str) -> Result<(), DbErr> {
         Self::down(database_path, None).await?;
 
-        let schema_manager = SpannerSchemaManager::new(database_path);
+        let schema_manager = SchemaManager::new(database_path);
         schema_manager.drop_table("seaql_migrations").await
     }
 }

--- a/sea-orm-migration-spanner/src/prelude.rs
+++ b/sea-orm-migration-spanner/src/prelude.rs
@@ -1,0 +1,12 @@
+//! Prelude module for sea-orm-migration-spanner
+//!
+//! Import this to get all commonly used types and traits:
+//! ```rust
+//! use sea_orm_migration_spanner::prelude::*;
+//! ```
+
+pub use crate::migrator::{MigrationName, MigrationStatus, MigrationTrait, MigratorTrait};
+pub use crate::schema::SchemaManager;
+pub use async_trait::async_trait;
+pub use sea_orm::DbErr;
+pub use sea_query_spanner::{SpannerAlterTable, SpannerIndexBuilder, SpannerTableBuilder};

--- a/sea-orm-migration-spanner/src/schema.rs
+++ b/sea-orm-migration-spanner/src/schema.rs
@@ -1,18 +1,30 @@
 use google_cloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
 use google_cloud_spanner::admin::database::database_admin_client::DatabaseAdminClient;
 use sea_orm::DbErr;
+use sea_query_spanner::{SpannerAlterTable, SpannerIndexBuilder, SpannerTableBuilder};
 
-pub struct SpannerSchemaManager {
+/// Schema manager for Spanner migrations
+///
+/// Provides methods to execute DDL statements against Spanner.
+/// Supports both raw DDL strings and builder patterns.
+pub struct SchemaManager {
     database_path: String,
 }
 
-impl SpannerSchemaManager {
+impl SchemaManager {
+    /// Create a new SchemaManager
     pub fn new(database_path: &str) -> Self {
         Self {
             database_path: database_path.to_string(),
         }
     }
 
+    /// Get the database path
+    pub fn database_path(&self) -> &str {
+        &self.database_path
+    }
+
+    /// Execute multiple DDL statements
     pub async fn execute_ddl(&self, statements: Vec<String>) -> Result<(), DbErr> {
         let db_client = DatabaseAdminClient::default()
             .await
@@ -51,21 +63,113 @@ impl SpannerSchemaManager {
         }
     }
 
-    pub async fn create_table(&self, ddl: &str) -> Result<(), DbErr> {
+    /// Execute a single DDL statement
+    pub async fn execute(&self, ddl: &str) -> Result<(), DbErr> {
         self.execute_ddl(vec![ddl.to_string()]).await
     }
 
+    // ========================================
+    // Table Operations
+    // ========================================
+
+    /// Create a table using raw DDL
+    pub async fn create_table_raw(&self, ddl: &str) -> Result<(), DbErr> {
+        self.execute_ddl(vec![ddl.to_string()]).await
+    }
+
+    /// Create a table using the builder
+    pub async fn create_table(&self, builder: SpannerTableBuilder) -> Result<(), DbErr> {
+        self.execute_ddl(vec![builder.build()]).await
+    }
+
+    /// Drop a table
     pub async fn drop_table(&self, table_name: &str) -> Result<(), DbErr> {
         self.execute_ddl(vec![format!("DROP TABLE {}", table_name)])
             .await
     }
 
-    pub async fn create_index(&self, ddl: &str) -> Result<(), DbErr> {
+    /// Drop a table if it exists (ignores errors if table doesn't exist)
+    pub async fn drop_table_if_exists(&self, table_name: &str) -> Result<(), DbErr> {
+        let result = self.drop_table(table_name).await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.contains("not found")
+                    || err_str.contains("does not exist")
+                    || err_str.contains("NOT_FOUND")
+                {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    // ========================================
+    // Index Operations
+    // ========================================
+
+    /// Create an index using raw DDL
+    pub async fn create_index_raw(&self, ddl: &str) -> Result<(), DbErr> {
         self.execute_ddl(vec![ddl.to_string()]).await
     }
 
+    /// Create an index using the builder
+    pub async fn create_index(&self, builder: SpannerIndexBuilder) -> Result<(), DbErr> {
+        self.execute_ddl(vec![builder.build()]).await
+    }
+
+    /// Drop an index
     pub async fn drop_index(&self, index_name: &str) -> Result<(), DbErr> {
         self.execute_ddl(vec![format!("DROP INDEX {}", index_name)])
             .await
+    }
+
+    /// Drop an index if it exists
+    pub async fn drop_index_if_exists(&self, index_name: &str) -> Result<(), DbErr> {
+        let result = self.drop_index(index_name).await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.contains("not found")
+                    || err_str.contains("does not exist")
+                    || err_str.contains("NOT_FOUND")
+                {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    // ========================================
+    // Alter Table Operations
+    // ========================================
+
+    /// Alter a table using the builder
+    pub async fn alter_table(&self, alter: SpannerAlterTable) -> Result<(), DbErr> {
+        self.execute_ddl(vec![alter.build()]).await
+    }
+
+    /// Add a column to a table
+    pub async fn add_column(
+        &self,
+        table: &str,
+        column_name: &str,
+        column_type: &str,
+        not_null: bool,
+    ) -> Result<(), DbErr> {
+        let alter = SpannerAlterTable::add_column(table, column_name, column_type, not_null);
+        self.execute_ddl(vec![alter.build()]).await
+    }
+
+    /// Drop a column from a table
+    pub async fn drop_column(&self, table: &str, column_name: &str) -> Result<(), DbErr> {
+        let alter = SpannerAlterTable::drop_column(table, column_name);
+        self.execute_ddl(vec![alter.build()]).await
     }
 }

--- a/sea-orm-migration-spanner/tests/migration_test.rs
+++ b/sea-orm-migration-spanner/tests/migration_test.rs
@@ -1,64 +1,67 @@
-use sea_orm::DbErr;
-use sea_orm_migration_spanner::{
-    SpannerMigrationTrait, SpannerMigratorTrait, SpannerSchemaManager,
-};
+use sea_orm_migration_spanner::prelude::*;
 use serial_test::serial;
 
 struct M20220101CreateUsers;
 
-#[async_trait::async_trait]
-impl SpannerMigrationTrait for M20220101CreateUsers {
+impl MigrationName for M20220101CreateUsers {
     fn name(&self) -> &str {
         "m20220101_000001_create_users"
     }
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+#[async_trait]
+impl MigrationTrait for M20220101CreateUsers {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .create_table(
-                "CREATE TABLE test_users (
-                    id STRING(36) NOT NULL,
-                    name STRING(255) NOT NULL,
-                    email STRING(255) NOT NULL,
-                ) PRIMARY KEY (id)",
+                SpannerTableBuilder::new()
+                    .table("test_users")
+                    .string("id", Some(36), true)
+                    .string("name", Some(255), true)
+                    .string("email", Some(255), true)
+                    .primary_key(["id"]),
             )
             .await
     }
 
-    async fn down(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager.drop_table("test_users").await
     }
 }
 
 struct M20220102CreatePosts;
 
-#[async_trait::async_trait]
-impl SpannerMigrationTrait for M20220102CreatePosts {
+impl MigrationName for M20220102CreatePosts {
     fn name(&self) -> &str {
         "m20220102_000001_create_posts"
     }
+}
 
-    async fn up(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+#[async_trait]
+impl MigrationTrait for M20220102CreatePosts {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .create_table(
-                "CREATE TABLE test_posts (
-                    id STRING(36) NOT NULL,
-                    user_id STRING(36) NOT NULL,
-                    title STRING(255) NOT NULL,
-                    content STRING(MAX),
-                ) PRIMARY KEY (id)",
+                SpannerTableBuilder::new()
+                    .table("test_posts")
+                    .string("id", Some(36), true)
+                    .string("user_id", Some(36), true)
+                    .string("title", Some(255), true)
+                    .string("content", None, false)
+                    .primary_key(["id"]),
             )
             .await
     }
 
-    async fn down(&self, manager: &SpannerSchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager.drop_table("test_posts").await
     }
 }
 
 struct TestMigrator;
 
-impl SpannerMigratorTrait for TestMigrator {
-    fn migrations() -> Vec<Box<dyn SpannerMigrationTrait>> {
+impl MigratorTrait for TestMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
             Box::new(M20220101CreateUsers),
             Box::new(M20220102CreatePosts),
@@ -142,11 +145,7 @@ async fn test_migration_up_and_down() {
     assert!(result.is_ok(), "Status check failed: {:?}", result.err());
 
     let result = TestMigrator::down(&db_path, Some(1)).await;
-    assert!(
-        result.is_ok(),
-        "Migration down failed: {:?}",
-        result.err()
-    );
+    assert!(result.is_ok(), "Migration down failed: {:?}", result.err());
 
     let result = TestMigrator::reset(&db_path).await;
     assert!(result.is_ok(), "Reset failed: {:?}", result.err());

--- a/sea-orm-spanner/src/error.rs
+++ b/sea-orm-spanner/src/error.rs
@@ -90,9 +90,14 @@ impl From<SpannerDbErr> for DbErr {
             SpannerDbErr::Execution(msg) => DbErr::Exec(sea_orm::RuntimeErr::Internal(msg)),
             SpannerDbErr::Transaction(msg) => DbErr::Query(sea_orm::RuntimeErr::Internal(msg)),
             SpannerDbErr::RowParse(msg) => DbErr::Type(msg),
-            SpannerDbErr::TypeConversion { column, expected, got } => {
-                DbErr::Type(format!("column={}, expected={}, got={}", column, expected, got))
-            }
+            SpannerDbErr::TypeConversion {
+                column,
+                expected,
+                got,
+            } => DbErr::Type(format!(
+                "column={}, expected={}, got={}",
+                column, expected, got
+            )),
             SpannerDbErr::ColumnNotFound(col) => DbErr::Type(format!("column not found: {}", col)),
             SpannerDbErr::InvalidConfig(msg) => DbErr::Conn(sea_orm::RuntimeErr::Internal(msg)),
         }

--- a/sea-orm-spanner/src/lib.rs
+++ b/sea-orm-spanner/src/lib.rs
@@ -1,5 +1,5 @@
-mod error;
 mod database;
+mod error;
 mod proxy;
 
 pub use database::SpannerDatabase;
@@ -8,8 +8,6 @@ pub use error::SpannerDbErr;
 pub use sea_query_spanner::SpannerQueryBuilder;
 
 pub use sea_orm::{
-    entity::prelude::*,
-    ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseConnection,
-    EntityTrait, IntoActiveModel, ModelTrait, QueryFilter, QueryOrder, QuerySelect,
-    Set, Unchanged,
+    entity::prelude::*, ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseConnection,
+    EntityTrait, IntoActiveModel, ModelTrait, QueryFilter, QueryOrder, QuerySelect, Set, Unchanged,
 };

--- a/sea-orm-spanner/src/proxy.rs
+++ b/sea-orm-spanner/src/proxy.rs
@@ -237,9 +237,19 @@ impl SpannerProxy {
                     .map(|s| {
                         let s = s.trim();
                         if let Some(as_pos) = s.to_uppercase().rfind(" AS ") {
-                            s[as_pos + 4..].trim().trim_matches('"').trim_matches('`').to_string()
+                            s[as_pos + 4..]
+                                .trim()
+                                .trim_matches('"')
+                                .trim_matches('`')
+                                .to_string()
                         } else if s.contains('.') {
-                            s.rsplit('.').next().unwrap_or(s).trim().trim_matches('"').trim_matches('`').to_string()
+                            s.rsplit('.')
+                                .next()
+                                .unwrap_or(s)
+                                .trim()
+                                .trim_matches('"')
+                                .trim_matches('`')
+                                .to_string()
                         } else {
                             s.trim_matches('"').trim_matches('`').to_string()
                         }
@@ -312,9 +322,7 @@ impl ProxyDatabaseTrait for SpannerProxy {
             .client
             .read_write_transaction(|tx, _cancel| {
                 let stmt = spanner_stmt.clone();
-                Box::pin(async move {
-                    tx.update(stmt).await.map_err(SpannerTxError::from)
-                })
+                Box::pin(async move { tx.update(stmt).await.map_err(SpannerTxError::from) })
             })
             .await
             .map_err(|e| SpannerDbErr::Execution(e.to_string()))?;

--- a/sea-orm-spanner/tests/activerecord_tests.rs
+++ b/sea-orm-spanner/tests/activerecord_tests.rs
@@ -38,7 +38,6 @@ mod insert_tests {
     #[tokio::test]
     #[serial]
     async fn test_insert_with_null_fields() {
-        
         let db = setup_test_database().await;
 
         let new_user = user::ActiveModel {
@@ -60,7 +59,6 @@ mod insert_tests {
     #[tokio::test]
     #[serial]
     async fn test_insert_multiple_entities() {
-        
         let db = setup_test_database().await;
 
         for i in 0..5 {
@@ -109,7 +107,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_by_id() {
-        
         let db = setup_test_database().await;
         let ids = setup_users(&db).await;
 
@@ -121,7 +118,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_all() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -132,7 +128,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_filter() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -147,7 +142,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_order_by() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -164,7 +158,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_limit() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -181,7 +174,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_offset() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -200,7 +192,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_one() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -217,7 +208,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_count() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -235,7 +225,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_contains() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -251,7 +240,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_in_list() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -267,7 +255,6 @@ mod select_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_is_null() {
-        
         let db = setup_test_database().await;
         setup_users(&db).await;
 
@@ -288,7 +275,6 @@ mod update_tests {
     #[tokio::test]
     #[serial]
     async fn test_update_single_field() {
-        
         let db = setup_test_database().await;
 
         let id = uuid::Uuid::new_v4().to_string();
@@ -302,12 +288,20 @@ mod update_tests {
         };
         new_user.insert(&db).await.unwrap();
 
-        let user = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let user = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         let mut active: user::ActiveModel = user.into_active_model();
         active.name = Set("Updated".to_string());
         active.update(&db).await.unwrap();
 
-        let updated = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let updated = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(updated.name, "Updated");
         assert_eq!(updated.email, "original@example.com");
     }
@@ -315,7 +309,6 @@ mod update_tests {
     #[tokio::test]
     #[serial]
     async fn test_update_multiple_fields() {
-        
         let db = setup_test_database().await;
 
         let id = uuid::Uuid::new_v4().to_string();
@@ -329,14 +322,22 @@ mod update_tests {
         };
         new_user.insert(&db).await.unwrap();
 
-        let user = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let user = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         let mut active: user::ActiveModel = user.into_active_model();
         active.name = Set("New Name".to_string());
         active.email = Set("new@example.com".to_string());
         active.age = Set(Some(30));
         active.update(&db).await.unwrap();
 
-        let updated = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let updated = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(updated.name, "New Name");
         assert_eq!(updated.email, "new@example.com");
         assert_eq!(updated.age, Some(30));
@@ -345,7 +346,6 @@ mod update_tests {
     #[tokio::test]
     #[serial]
     async fn test_update_to_null() {
-        
         let db = setup_test_database().await;
 
         let id = uuid::Uuid::new_v4().to_string();
@@ -359,12 +359,20 @@ mod update_tests {
         };
         new_user.insert(&db).await.unwrap();
 
-        let user = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let user = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         let mut active: user::ActiveModel = user.into_active_model();
         active.age = Set(None);
         active.update(&db).await.unwrap();
 
-        let updated = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let updated = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(updated.age.is_none());
     }
 }
@@ -375,7 +383,6 @@ mod delete_tests {
     #[tokio::test]
     #[serial]
     async fn test_delete_single_entity() {
-        
         let db = setup_test_database().await;
 
         let id = uuid::Uuid::new_v4().to_string();
@@ -389,7 +396,11 @@ mod delete_tests {
         };
         new_user.insert(&db).await.unwrap();
 
-        let user = user::Entity::find_by_id(&id).one(&db).await.unwrap().unwrap();
+        let user = user::Entity::find_by_id(&id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
         user.delete(&db).await.unwrap();
 
         let deleted = user::Entity::find_by_id(&id).one(&db).await.unwrap();
@@ -399,7 +410,6 @@ mod delete_tests {
     #[tokio::test]
     #[serial]
     async fn test_delete_by_filter() {
-        
         let db = setup_test_database().await;
 
         for i in 0..5 {
@@ -464,7 +474,6 @@ mod relation_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_related() {
-        
         let db = setup_test_database().await;
         let (user_id, _) = setup_users_and_posts(&db).await;
 
@@ -481,7 +490,6 @@ mod relation_tests {
     #[tokio::test]
     #[serial]
     async fn test_find_with_related() {
-        
         let db = setup_test_database().await;
         setup_users_and_posts(&db).await;
 
@@ -502,7 +510,6 @@ mod pagination_tests {
     #[tokio::test]
     #[serial]
     async fn test_paginator() {
-        
         let db = setup_test_database().await;
 
         for i in 0..25 {
@@ -583,7 +590,6 @@ mod complex_query_tests {
     #[tokio::test]
     #[serial]
     async fn test_complex_filter() {
-        
         let db = setup_test_database().await;
         setup_products(&db).await;
 
@@ -600,7 +606,6 @@ mod complex_query_tests {
     #[tokio::test]
     #[serial]
     async fn test_or_filter() {
-        
         let db = setup_test_database().await;
         setup_products(&db).await;
 
@@ -622,7 +627,6 @@ mod complex_query_tests {
     #[tokio::test]
     #[serial]
     async fn test_select_only() {
-        
         let db = setup_test_database().await;
         setup_products(&db).await;
 

--- a/sea-orm-spanner/tests/common/mod.rs
+++ b/sea-orm-spanner/tests/common/mod.rs
@@ -55,7 +55,9 @@ pub async fn setup_test_database() -> DatabaseConnection {
 
     if !INITIALIZED.load(Ordering::SeqCst) {
         setup_instance().await.ok();
-        ensure_database_exists().await.expect("Failed to create database");
+        ensure_database_exists()
+            .await
+            .expect("Failed to create database");
         ensure_tables_exist().await;
         INITIALIZED.store(true, Ordering::SeqCst);
     }
@@ -168,10 +170,7 @@ async fn clear_tables(db: &DatabaseConnection) {
     for table in ALL_TABLES {
         let sql = format!("DELETE FROM {} WHERE true", table);
         let _ = db
-            .execute(Statement::from_string(
-                sea_orm::DatabaseBackend::MySql,
-                sql,
-            ))
+            .execute(Statement::from_string(sea_orm::DatabaseBackend::MySql, sql))
             .await;
     }
 }

--- a/sea-orm-spanner/tests/entity/mod.rs
+++ b/sea-orm-spanner/tests/entity/mod.rs
@@ -1,4 +1,4 @@
-pub mod user;
-pub mod post;
 pub mod category;
+pub mod post;
 pub mod product;
+pub mod user;

--- a/sea-query-spanner/src/lib.rs
+++ b/sea-query-spanner/src/lib.rs
@@ -1,9 +1,11 @@
-mod query_builder;
-mod types;
 mod functions;
+mod query_builder;
+mod schema;
+mod types;
 mod value;
 
-pub use query_builder::SpannerQueryBuilder;
-pub use types::*;
 pub use functions::*;
+pub use query_builder::SpannerQueryBuilder;
+pub use schema::*;
+pub use types::*;
 pub use value::*;

--- a/sea-query-spanner/src/query_builder.rs
+++ b/sea-query-spanner/src/query_builder.rs
@@ -1,5 +1,8 @@
 use sea_query::{
-    backend::{EscapeBuilder, OperLeftAssocDecider, PrecedenceDecider, QueryBuilder, QuotedBuilder, TableRefBuilder},
+    backend::{
+        EscapeBuilder, OperLeftAssocDecider, PrecedenceDecider, QueryBuilder, QuotedBuilder,
+        TableRefBuilder,
+    },
     BinOper, Oper, Quote, SimpleExpr, SqlWriter, SubQueryStatement, Value,
 };
 
@@ -138,10 +141,7 @@ mod tests {
             .and_where(Expr::col(Alias::new("id")).eq(1))
             .to_string(SpannerQueryBuilder);
 
-        assert_eq!(
-            query,
-            r#"UPDATE `users` SET `name` = 'Bob' WHERE `id` = 1"#
-        );
+        assert_eq!(query, r#"UPDATE `users` SET `name` = 'Bob' WHERE `id` = 1"#);
     }
 
     #[test]
@@ -169,7 +169,10 @@ mod tests {
             .and_where(Expr::col(Alias::new("active")).eq(true))
             .build(SpannerQueryBuilder);
 
-        assert_eq!(sql, r#"SELECT `name` FROM `users` WHERE (`id` = @p1) AND (`active` = @p2)"#);
+        assert_eq!(
+            sql,
+            r#"SELECT `name` FROM `users` WHERE (`id` = @p1) AND (`active` = @p2)"#
+        );
         assert_eq!(values.0.len(), 2);
     }
 }

--- a/sea-query-spanner/src/schema.rs
+++ b/sea-query-spanner/src/schema.rs
@@ -1,0 +1,587 @@
+//! Spanner DDL Schema Builder
+//!
+//! Provides a fluent API for building Spanner DDL statements.
+//! This is separate from SeaQuery's TableBuilder because Spanner DDL
+//! has significant differences from standard SQL DDL.
+
+use crate::types::spanner_type_name;
+use sea_query::ColumnType;
+
+/// Builder for CREATE TABLE statements in Spanner DDL format
+#[derive(Debug, Clone, Default)]
+pub struct SpannerTableBuilder {
+    table_name: String,
+    columns: Vec<SpannerColumn>,
+    primary_keys: Vec<String>,
+    interleave_in_parent: Option<String>,
+    on_delete_cascade: bool,
+    row_deletion_policy: Option<String>,
+}
+
+/// Represents a column definition for Spanner
+#[derive(Debug, Clone)]
+pub struct SpannerColumn {
+    name: String,
+    column_type: String,
+    not_null: bool,
+    default_expr: Option<String>,
+    generated_expr: Option<String>,
+    stored: bool,
+}
+
+impl SpannerTableBuilder {
+    /// Create a new table builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the table name
+    pub fn table<S: Into<String>>(mut self, name: S) -> Self {
+        self.table_name = name.into();
+        self
+    }
+
+    /// Add a column with a SeaQuery ColumnType
+    pub fn col<S: Into<String>>(mut self, name: S, col_type: &ColumnType, not_null: bool) -> Self {
+        self.columns.push(SpannerColumn {
+            name: name.into(),
+            column_type: spanner_type_name(col_type),
+            not_null,
+            default_expr: None,
+            generated_expr: None,
+            stored: false,
+        });
+        self
+    }
+
+    /// Add a column with a raw Spanner type string
+    pub fn col_raw<S: Into<String>, T: Into<String>>(
+        mut self,
+        name: S,
+        spanner_type: T,
+        not_null: bool,
+    ) -> Self {
+        self.columns.push(SpannerColumn {
+            name: name.into(),
+            column_type: spanner_type.into(),
+            not_null,
+            default_expr: None,
+            generated_expr: None,
+            stored: false,
+        });
+        self
+    }
+
+    /// Add a STRING column
+    pub fn string<S: Into<String>>(self, name: S, max_len: Option<u32>, not_null: bool) -> Self {
+        let type_str = match max_len {
+            Some(len) => format!("STRING({})", len),
+            None => "STRING(MAX)".to_string(),
+        };
+        self.col_raw(name, type_str, not_null)
+    }
+
+    /// Add an INT64 column
+    pub fn int64<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "INT64", not_null)
+    }
+
+    /// Add a FLOAT64 column
+    pub fn float64<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "FLOAT64", not_null)
+    }
+
+    /// Add a BOOL column
+    pub fn bool<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "BOOL", not_null)
+    }
+
+    /// Add a BYTES column
+    pub fn bytes<S: Into<String>>(self, name: S, max_len: Option<u32>, not_null: bool) -> Self {
+        let type_str = match max_len {
+            Some(len) => format!("BYTES({})", len),
+            None => "BYTES(MAX)".to_string(),
+        };
+        self.col_raw(name, type_str, not_null)
+    }
+
+    /// Add a DATE column
+    pub fn date<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "DATE", not_null)
+    }
+
+    /// Add a TIMESTAMP column
+    pub fn timestamp<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "TIMESTAMP", not_null)
+    }
+
+    /// Add a JSON column
+    pub fn json<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "JSON", not_null)
+    }
+
+    /// Add a NUMERIC column
+    pub fn numeric<S: Into<String>>(self, name: S, not_null: bool) -> Self {
+        self.col_raw(name, "NUMERIC", not_null)
+    }
+
+    /// Add a column with DEFAULT expression
+    pub fn col_with_default<S: Into<String>, T: Into<String>, D: Into<String>>(
+        mut self,
+        name: S,
+        spanner_type: T,
+        not_null: bool,
+        default_expr: D,
+    ) -> Self {
+        self.columns.push(SpannerColumn {
+            name: name.into(),
+            column_type: spanner_type.into(),
+            not_null,
+            default_expr: Some(default_expr.into()),
+            generated_expr: None,
+            stored: false,
+        });
+        self
+    }
+
+    /// Add a generated column
+    pub fn col_generated<S: Into<String>, T: Into<String>, E: Into<String>>(
+        mut self,
+        name: S,
+        spanner_type: T,
+        expr: E,
+        stored: bool,
+    ) -> Self {
+        self.columns.push(SpannerColumn {
+            name: name.into(),
+            column_type: spanner_type.into(),
+            not_null: false,
+            default_expr: None,
+            generated_expr: Some(expr.into()),
+            stored,
+        });
+        self
+    }
+
+    /// Set primary key columns
+    pub fn primary_key<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.primary_keys = columns.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set INTERLEAVE IN PARENT clause
+    pub fn interleave_in_parent<S: Into<String>>(mut self, parent_table: S) -> Self {
+        self.interleave_in_parent = Some(parent_table.into());
+        self
+    }
+
+    /// Set ON DELETE CASCADE for interleaved table
+    pub fn on_delete_cascade(mut self) -> Self {
+        self.on_delete_cascade = true;
+        self
+    }
+
+    /// Set row deletion policy (TTL)
+    pub fn row_deletion_policy<S: Into<String>>(mut self, column: S, days: u32) -> Self {
+        self.row_deletion_policy = Some(format!(
+            "OLDER_THAN({}, INTERVAL {} DAY)",
+            column.into(),
+            days
+        ));
+        self
+    }
+
+    /// Build the CREATE TABLE DDL statement
+    pub fn build(self) -> String {
+        let mut ddl = format!("CREATE TABLE {} (\n", self.table_name);
+
+        for (i, col) in self.columns.iter().enumerate() {
+            if i > 0 {
+                ddl.push_str(",\n");
+            }
+            ddl.push_str("  ");
+            ddl.push_str(&col.name);
+            ddl.push(' ');
+            ddl.push_str(&col.column_type);
+
+            if col.not_null {
+                ddl.push_str(" NOT NULL");
+            }
+
+            if let Some(default) = &col.default_expr {
+                ddl.push_str(" DEFAULT (");
+                ddl.push_str(default);
+                ddl.push(')');
+            }
+
+            if let Some(gen) = &col.generated_expr {
+                ddl.push_str(" AS (");
+                ddl.push_str(gen);
+                ddl.push(')');
+                if col.stored {
+                    ddl.push_str(" STORED");
+                }
+            }
+        }
+
+        ddl.push_str("\n) PRIMARY KEY (");
+        ddl.push_str(&self.primary_keys.join(", "));
+        ddl.push(')');
+
+        if let Some(parent) = &self.interleave_in_parent {
+            ddl.push_str(",\n  INTERLEAVE IN PARENT ");
+            ddl.push_str(parent);
+            if self.on_delete_cascade {
+                ddl.push_str(" ON DELETE CASCADE");
+            }
+        }
+
+        if let Some(policy) = &self.row_deletion_policy {
+            ddl.push_str(",\n  ROW DELETION POLICY (");
+            ddl.push_str(policy);
+            ddl.push(')');
+        }
+
+        ddl
+    }
+}
+
+/// Builder for CREATE INDEX statements in Spanner DDL format
+#[derive(Debug, Clone, Default)]
+pub struct SpannerIndexBuilder {
+    index_name: String,
+    table_name: String,
+    columns: Vec<(String, Option<bool>)>, // (column_name, is_desc)
+    unique: bool,
+    null_filtered: bool,
+    storing: Vec<String>,
+    interleave_in: Option<String>,
+}
+
+impl SpannerIndexBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set index name
+    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
+        self.index_name = name.into();
+        self
+    }
+
+    /// Set table name
+    pub fn table<S: Into<String>>(mut self, name: S) -> Self {
+        self.table_name = name.into();
+        self
+    }
+
+    /// Add a column to the index
+    pub fn col<S: Into<String>>(mut self, name: S) -> Self {
+        self.columns.push((name.into(), None));
+        self
+    }
+
+    /// Add a column with ASC order
+    pub fn col_asc<S: Into<String>>(mut self, name: S) -> Self {
+        self.columns.push((name.into(), Some(false)));
+        self
+    }
+
+    /// Add a column with DESC order
+    pub fn col_desc<S: Into<String>>(mut self, name: S) -> Self {
+        self.columns.push((name.into(), Some(true)));
+        self
+    }
+
+    /// Make this a unique index
+    pub fn unique(mut self) -> Self {
+        self.unique = true;
+        self
+    }
+
+    /// Make this a null-filtered index
+    pub fn null_filtered(mut self) -> Self {
+        self.null_filtered = true;
+        self
+    }
+
+    /// Add STORING columns
+    pub fn storing<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.storing = columns.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set INTERLEAVE IN clause
+    pub fn interleave_in<S: Into<String>>(mut self, table: S) -> Self {
+        self.interleave_in = Some(table.into());
+        self
+    }
+
+    /// Build the CREATE INDEX DDL statement
+    pub fn build(self) -> String {
+        let mut ddl = String::new();
+        ddl.push_str("CREATE ");
+
+        if self.unique {
+            ddl.push_str("UNIQUE ");
+        }
+        if self.null_filtered {
+            ddl.push_str("NULL_FILTERED ");
+        }
+
+        ddl.push_str("INDEX ");
+        ddl.push_str(&self.index_name);
+        ddl.push_str(" ON ");
+        ddl.push_str(&self.table_name);
+        ddl.push_str(" (");
+
+        for (i, (col, order)) in self.columns.iter().enumerate() {
+            if i > 0 {
+                ddl.push_str(", ");
+            }
+            ddl.push_str(col);
+            if let Some(is_desc) = order {
+                ddl.push_str(if *is_desc { " DESC" } else { " ASC" });
+            }
+        }
+
+        ddl.push(')');
+
+        if !self.storing.is_empty() {
+            ddl.push_str(" STORING (");
+            ddl.push_str(&self.storing.join(", "));
+            ddl.push(')');
+        }
+
+        if let Some(table) = &self.interleave_in {
+            ddl.push_str(", INTERLEAVE IN ");
+            ddl.push_str(table);
+        }
+
+        ddl
+    }
+}
+
+/// Builder for ALTER TABLE statements in Spanner DDL format
+#[derive(Debug, Clone)]
+pub enum SpannerAlterTable {
+    AddColumn {
+        table: String,
+        column: SpannerColumn,
+    },
+    DropColumn {
+        table: String,
+        column: String,
+    },
+    AlterColumn {
+        table: String,
+        column: String,
+        new_type: Option<String>,
+        set_not_null: Option<bool>,
+        set_default: Option<String>,
+        drop_default: bool,
+    },
+    AddForeignKey {
+        table: String,
+        constraint_name: String,
+        columns: Vec<String>,
+        ref_table: String,
+        ref_columns: Vec<String>,
+        on_delete: Option<String>,
+    },
+    DropConstraint {
+        table: String,
+        constraint_name: String,
+    },
+}
+
+impl SpannerAlterTable {
+    pub fn add_column<T: Into<String>, N: Into<String>, S: Into<String>>(
+        table: T,
+        name: N,
+        spanner_type: S,
+        not_null: bool,
+    ) -> Self {
+        Self::AddColumn {
+            table: table.into(),
+            column: SpannerColumn {
+                name: name.into(),
+                column_type: spanner_type.into(),
+                not_null,
+                default_expr: None,
+                generated_expr: None,
+                stored: false,
+            },
+        }
+    }
+
+    pub fn drop_column<T: Into<String>, N: Into<String>>(table: T, column: N) -> Self {
+        Self::DropColumn {
+            table: table.into(),
+            column: column.into(),
+        }
+    }
+
+    pub fn build(self) -> String {
+        match self {
+            Self::AddColumn { table, column } => {
+                let mut ddl = format!(
+                    "ALTER TABLE {} ADD COLUMN {} {}",
+                    table, column.name, column.column_type
+                );
+                if column.not_null {
+                    ddl.push_str(" NOT NULL");
+                }
+                if let Some(default) = column.default_expr {
+                    ddl.push_str(" DEFAULT (");
+                    ddl.push_str(&default);
+                    ddl.push(')');
+                }
+                ddl
+            }
+            Self::DropColumn { table, column } => {
+                format!("ALTER TABLE {} DROP COLUMN {}", table, column)
+            }
+            Self::AlterColumn {
+                table,
+                column,
+                new_type,
+                set_not_null,
+                set_default,
+                drop_default,
+            } => {
+                let mut ddl = format!("ALTER TABLE {} ALTER COLUMN {}", table, column);
+                if let Some(t) = new_type {
+                    ddl.push(' ');
+                    ddl.push_str(&t);
+                }
+                if let Some(nn) = set_not_null {
+                    if nn {
+                        ddl.push_str(" NOT NULL");
+                    }
+                }
+                if let Some(def) = set_default {
+                    ddl.push_str(" DEFAULT (");
+                    ddl.push_str(&def);
+                    ddl.push(')');
+                }
+                if drop_default {
+                    ddl.push_str(" DROP DEFAULT");
+                }
+                ddl
+            }
+            Self::AddForeignKey {
+                table,
+                constraint_name,
+                columns,
+                ref_table,
+                ref_columns,
+                on_delete,
+            } => {
+                let mut ddl = format!(
+                    "ALTER TABLE {} ADD CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {} ({})",
+                    table,
+                    constraint_name,
+                    columns.join(", "),
+                    ref_table,
+                    ref_columns.join(", ")
+                );
+                if let Some(action) = on_delete {
+                    ddl.push_str(" ON DELETE ");
+                    ddl.push_str(&action);
+                }
+                ddl
+            }
+            Self::DropConstraint {
+                table,
+                constraint_name,
+            } => {
+                format!("ALTER TABLE {} DROP CONSTRAINT {}", table, constraint_name)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_table_basic() {
+        let ddl = SpannerTableBuilder::new()
+            .table("users")
+            .string("id", Some(36), true)
+            .string("name", None, true)
+            .string("email", None, false)
+            .timestamp("created_at", true)
+            .primary_key(["id"])
+            .build();
+
+        assert_eq!(
+            ddl,
+            "CREATE TABLE users (\n  id STRING(36) NOT NULL,\n  name STRING(MAX) NOT NULL,\n  email STRING(MAX),\n  created_at TIMESTAMP NOT NULL\n) PRIMARY KEY (id)"
+        );
+    }
+
+    #[test]
+    fn test_create_table_interleaved() {
+        let ddl = SpannerTableBuilder::new()
+            .table("posts")
+            .string("user_id", Some(36), true)
+            .string("post_id", Some(36), true)
+            .string("content", None, true)
+            .primary_key(["user_id", "post_id"])
+            .interleave_in_parent("users")
+            .on_delete_cascade()
+            .build();
+
+        assert!(ddl.contains("INTERLEAVE IN PARENT users ON DELETE CASCADE"));
+    }
+
+    #[test]
+    fn test_create_index() {
+        let ddl = SpannerIndexBuilder::new()
+            .name("idx_users_email")
+            .table("users")
+            .col("email")
+            .unique()
+            .build();
+
+        assert_eq!(ddl, "CREATE UNIQUE INDEX idx_users_email ON users (email)");
+    }
+
+    #[test]
+    fn test_create_index_with_storing() {
+        let ddl = SpannerIndexBuilder::new()
+            .name("idx_users_name")
+            .table("users")
+            .col("name")
+            .storing(["email", "created_at"])
+            .build();
+
+        assert_eq!(
+            ddl,
+            "CREATE INDEX idx_users_name ON users (name) STORING (email, created_at)"
+        );
+    }
+
+    #[test]
+    fn test_alter_table_add_column() {
+        let ddl = SpannerAlterTable::add_column("users", "age", "INT64", false).build();
+        assert_eq!(ddl, "ALTER TABLE users ADD COLUMN age INT64");
+    }
+
+    #[test]
+    fn test_alter_table_drop_column() {
+        let ddl = SpannerAlterTable::drop_column("users", "age").build();
+        assert_eq!(ddl, "ALTER TABLE users DROP COLUMN age");
+    }
+}

--- a/sea-query-spanner/src/types.rs
+++ b/sea-query-spanner/src/types.rs
@@ -3,12 +3,14 @@ use sea_query::ColumnType;
 pub fn spanner_type_name(col_type: &ColumnType) -> String {
     match col_type {
         ColumnType::Char(_) | ColumnType::String(_) | ColumnType::Text => "STRING(MAX)".to_string(),
-        ColumnType::TinyInteger | ColumnType::SmallInteger | ColumnType::Integer | ColumnType::BigInteger => {
-            "INT64".to_string()
-        }
-        ColumnType::TinyUnsigned | ColumnType::SmallUnsigned | ColumnType::Unsigned | ColumnType::BigUnsigned => {
-            "INT64".to_string()
-        }
+        ColumnType::TinyInteger
+        | ColumnType::SmallInteger
+        | ColumnType::Integer
+        | ColumnType::BigInteger => "INT64".to_string(),
+        ColumnType::TinyUnsigned
+        | ColumnType::SmallUnsigned
+        | ColumnType::Unsigned
+        | ColumnType::BigUnsigned => "INT64".to_string(),
         ColumnType::Float => "FLOAT32".to_string(),
         ColumnType::Double => "FLOAT64".to_string(),
         ColumnType::Decimal(_) | ColumnType::Money(_) => "NUMERIC".to_string(),
@@ -19,7 +21,9 @@ pub fn spanner_type_name(col_type: &ColumnType) -> String {
         ColumnType::Date => "DATE".to_string(),
         ColumnType::Year => "INT64".to_string(),
         ColumnType::Interval(_, _) => "INT64".to_string(),
-        ColumnType::Binary(_) | ColumnType::VarBinary(_) | ColumnType::Blob => "BYTES(MAX)".to_string(),
+        ColumnType::Binary(_) | ColumnType::VarBinary(_) | ColumnType::Blob => {
+            "BYTES(MAX)".to_string()
+        }
         ColumnType::Bit(_) => "BYTES(MAX)".to_string(),
         ColumnType::Boolean => "BOOL".to_string(),
         ColumnType::Json | ColumnType::JsonBinary => "JSON".to_string(),

--- a/sea-query-spanner/src/value.rs
+++ b/sea-query-spanner/src/value.rs
@@ -39,19 +39,27 @@ pub fn value_to_spanner_literal(value: &Value) -> String {
         #[cfg(feature = "with-chrono")]
         Value::ChronoTime(None) => "NULL".to_string(),
         #[cfg(feature = "with-chrono")]
-        Value::ChronoDateTime(Some(dt)) => format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ")),
+        Value::ChronoDateTime(Some(dt)) => {
+            format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
+        }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTime(None) => "NULL".to_string(),
         #[cfg(feature = "with-chrono")]
-        Value::ChronoDateTimeUtc(Some(dt)) => format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ")),
+        Value::ChronoDateTimeUtc(Some(dt)) => {
+            format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
+        }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeUtc(None) => "NULL".to_string(),
         #[cfg(feature = "with-chrono")]
-        Value::ChronoDateTimeLocal(Some(dt)) => format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ")),
+        Value::ChronoDateTimeLocal(Some(dt)) => {
+            format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
+        }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(None) => "NULL".to_string(),
         #[cfg(feature = "with-chrono")]
-        Value::ChronoDateTimeWithTimeZone(Some(dt)) => format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ")),
+        Value::ChronoDateTimeWithTimeZone(Some(dt)) => {
+            format!("TIMESTAMP '{}'", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
+        }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeWithTimeZone(None) => "NULL".to_string(),
         #[cfg(feature = "with-uuid")]


### PR DESCRIPTION
## Summary

- Add `MigrationName` trait separated from `MigrationTrait` (matching sea-orm-migration structure)
- Rename traits: `SpannerMigrationTrait` → `MigrationTrait`, `SpannerMigratorTrait` → `MigratorTrait`
- Rename `SpannerSchemaManager` → `SchemaManager`
- Add `prelude` module for convenient imports
- Add fluent DDL builders: `SpannerTableBuilder`, `SpannerIndexBuilder`, `SpannerAlterTable`
- Update repository URL in Cargo.toml to correct location

## Breaking Changes

Migration trait names changed. Update imports:
```rust
// Before
use sea_orm_migration_spanner::{SpannerMigrationTrait, SpannerSchemaManager};

// After
use sea_orm_migration_spanner::prelude::*;
```

## Test Plan

- `cargo check` passes
- `cargo test` compiles successfully (tests require Spanner emulator)
- Examples updated and compile