### PR TITLE
fix: pin sea-orm dependencies to tag 2.0.0-rc.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ runtime-async-std-native-tls = ["sea-orm/runtime-async-std-native-tls"]
 runtime-async-std-rustls = ["sea-orm/runtime-async-std-rustls"]
 
 [dependencies]
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091", default-features = false, features = [
+sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32", default-features = false, features = [
     "proxy",
 ] }
 sea-query = { version = "1.0.0-rc.31", default-features = false }
@@ -87,7 +87,7 @@ gcloud-spanner = { git = "https://github.com/devgony/google-cloud-rust.git", bra
 gcloud-googleapis = { git = "https://github.com/devgony/google-cloud-rust.git", branch = "support-uuid", features = [
     "spanner",
 ] }
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091", features = [
+sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32", features = [
     "proxy",
     "macros",
     "with-chrono",

--- a/examples/basic-crud/Cargo.toml
+++ b/examples/basic-crud/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 sea-orm-spanner = { path = "../..", features = ["with-chrono", "with-uuid"] }
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091", features = [
+sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32", features = [
     "macros",
     "with-chrono",
     "with-uuid",

--- a/examples/migration/Cargo.toml
+++ b/examples/migration/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 sea-orm-migration-spanner = { path = "../../sea-orm-migration-spanner" }
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091", features = [
+sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32", features = [
     "runtime-tokio-native-tls",
 ] }
 tokio = { version = "1", features = ["full"] }

--- a/sea-orm-migration-spanner/Cargo.toml
+++ b/sea-orm-migration-spanner/Cargo.toml
@@ -17,11 +17,11 @@ name = "sea_orm_migration_spanner"
 path = "src/lib.rs"
 
 [dependencies]
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091", features = [
+sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32", features = [
     "runtime-tokio-native-tls",
     "macros",
 ] }
-sea-orm-migration = { git = "https://github.com/SeaQL/sea-orm.git", rev = "63e6e491eb95961818c84b1329fb1021797f0091" }
+sea-orm-migration = { git = "https://github.com/SeaQL/sea-orm.git", tag = "2.0.0-rc.32" }
 sea-orm-spanner = { path = ".." }
 sea-query-spanner = { path = "../sea-query-spanner" }
 gcloud-spanner = { git = "https://github.com/devgony/google-cloud-rust.git", branch = "support-uuid", features = [


### PR DESCRIPTION
## Summary
- Replace `rev = "63e6e491..."` with `tag = "2.0.0-rc.32"` for all `sea-orm` and `sea-orm-migration` git dependencies
- Affected files: root `Cargo.toml`, `sea-orm-migration-spanner/Cargo.toml`, `examples/migration/Cargo.toml`, `examples/basic-crud/Cargo.toml` (4 files, 6 dependency entries)
- sea-orm 2.0.0-rc.32 is not yet published to crates.io, so git tag reference is used instead of version

## Test plan
- `cargo check` across workspace to verify dependency resolution