### PR TITLE
chore: add renovate config to pin GitHub Actions digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Record the most specific upstream version in the comment next to each pinned SHA. Equivalent to helpers:pinGitHubActionDigestsToSemver, but with a looser extractVersion so that actions publishing only a major tag (e.g. v21) are still tracked.",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "extractVersion": "^(?<version>v?\\d+(\\.\\d+)*)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "pinDigest (the initial SHA pin) stays pending forever due to a Renovate bug with stability days, so create it immediately.",
+      "matchDepTypes": ["action"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Adds a `renovate.json` so that Renovate pins every GitHub Actions reference to a commit SHA, and waits out a cooldown before proposing dependency updates.

- `helpers:pinGitHubActionDigests` — pins every GitHub Actions reference to a commit SHA
- `minimumReleaseAge: "7 days"` — a 7-day cooldown across all datasources
- Records the most specific upstream version as a comment next to each pinned SHA. This is `helpers:pinGitHubActionDigestsToSemver` with a looser `extractVersion`, so that actions publishing only a major tag (e.g. `v21`) are still tracked
- Creates the initial pin immediately, working around the Renovate bug where a `pinDigest` update stays pending forever while stability days apply

Once this is merged, Renovate opens a follow-up PR that pins each `uses:` reference to a SHA.

> [!NOTE]
> The Renovate App is not enabled on this repository yet, so the follow-up pin PR will only show up once it is.

### Heads-up: branch references will not be pinned

`dtolnay/rust-toolchain@stable` and `dtolnay/rust-toolchain@nightly` are branch references. `helpers:pinGitHubActionDigests` only pins tags, so Renovate will leave these as-is and they will still need to be handled by hand.

### AI assistance used
- [x] Claude Code